### PR TITLE
add leading dot to output path to be compatible with jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Given the following JSON object:
 	}
 }
 ```
-In this scenario the plugin will display/copy the following JSONPaths:
+In this scenario the plugin will display/copy the following JSONPaths (all directly queryable in [`jq`](https://jqlang.github.io/jq/) for matching results):
 
-- Cursor inside "name": `name`
-- Cursor inside "Hello World": `name`
-- Cursor inside "tags": `tags`
-- Cursor inside "example": `tags[0]`
-- Cursor inside "metadata": `metadata`
-- Cursor inside "author": `metadata.author`
+- Cursor inside "name": `.name`
+- Cursor inside "Hello World": `.name`
+- Cursor inside "tags": `.tags`
+- Cursor inside "example": `.tags[0]`
+- Cursor inside "metadata": `.metadata`
+- Cursor inside "author": `.metadata.author`
 
 ## Demo
 ![screen recording](statusbarjsonpath.gif)

--- a/StatusBarJsonPath.py
+++ b/StatusBarJsonPath.py
@@ -97,6 +97,8 @@ def path_to_string(path):
 					s += '["' + frame['key'] + '"]'
 		else:
 			s += '[' + str(frame['index']) + ']'
+	if s != '':
+		s = '.' + s
 	return s
 
 


### PR DESCRIPTION
This PR changes the path which is displayed in the status bar and copied to the clipboard to include a leading `.`, so that the path will directly work with the `jq` command line tool.