### PR TITLE
fix to not show the previous key when in whitespace between prev value and next key

### DIFF
--- a/StatusBarJsonPath.py
+++ b/StatusBarJsonPath.py
@@ -80,6 +80,10 @@ def json_path_to(text,offset):
 			stack.append(dict(col_type='array',index=0))
 		elif text[pos] == '}' or text[pos] == ']':
 			stack.pop()
+			if len(stack):
+				frame = stack[-1]
+				if frame['col_type'] == 'object':
+					frame.pop('key', None)
 		elif text[pos] == ',':
 			if len(stack):
 				frame = stack[-1]

--- a/StatusBarJsonPath.py
+++ b/StatusBarJsonPath.py
@@ -69,9 +69,12 @@ def json_path_to(text,offset):
 			s, new_pos = read_string(text, pos)
 			if len(stack):
 				frame = stack[-1]
-				if frame['col_type'] == 'object' and is_in_key:
-					frame['key'] = s
-					is_in_key = False
+				if frame['col_type'] == 'object':
+					if is_in_key:
+						frame['key'] = s
+						is_in_key = False
+					elif new_pos <= offset:
+						frame.pop('key', None)
 			pos = new_pos
 		elif text[pos] == '{':
 			stack.append(dict(col_type='object'))

--- a/StatusBarJsonPath.py
+++ b/StatusBarJsonPath.py
@@ -85,6 +85,7 @@ def json_path_to(text,offset):
 				frame = stack[-1]
 				if frame['col_type'] == 'object':
 					is_in_key = True
+					frame.pop('key', None)
 				elif frame['col_type'] == 'array':
 					frame['index'] += 1
 


### PR DESCRIPTION
currently, given the example file
```json
{
	"name": "Hello World",
	"tags": [
		"example"
	],
	"metadata": {
		"author": "Alex Kirk"
	}
}
```
if the selection is after the closing quote after `Kirk`, the status bar still shows the json path as being in the `author` field, but I believe it should only show `metadata`. Similarly, if the selection caret is right before the final `}` (i.e. at the beginning of the last line), it still shows `metadata`, but I think it should show nothing.

This PR changes it to behave this way.