### PR TITLE
show status message when copying JSON path to the clipboard

### DIFF
--- a/StatusBarJsonPath.py
+++ b/StatusBarJsonPath.py
@@ -9,6 +9,9 @@ class CopyJsonPathCommand(sublime_plugin.TextCommand):
 		print(json_paths)
 		if len(json_paths):
 			sublime.set_clipboard( ", ".join(json_paths))
+			self.view.window().status_message('Copied json path to clipboard.')
+		else:
+			self.view.window().status_message('No json path to copy to the clipboard.')
 
 class StatusBarJsonPath(sublime_plugin.EventListener):
 	KEY_SIZE = "JSONPath"


### PR DESCRIPTION
To make the user experience a bit better, show a status message when copying JSON path to the clipboard. Also show something when nothing was copied, to avoid the user getting confused why the clipboard wasn't updated.