### PR TITLE
only show JSON path entry in command palette if at least one caret is in a JSON region

### DIFF
--- a/StatusBarJsonPath.py
+++ b/StatusBarJsonPath.py
@@ -10,6 +10,10 @@ class CopyJsonPathCommand(sublime_plugin.TextCommand):
 		if len(json_paths):
 			sublime.set_clipboard( ", ".join(json_paths))
 
+	def is_visible(self):
+		return any(self.view.match_selector(region.a, 'source.json') for region in self.view.sel())
+
+
 class StatusBarJsonPath(sublime_plugin.EventListener):
 	KEY_SIZE = "JSONPath"
 


### PR DESCRIPTION
I had the idea that it would make sense to only show the JSON path entry in the command palette if at least one caret is inside a JSON region, to reduce clutter and any chance of it "getting in the way".

Thanks for this great plugin btw, sorry for the flood of PRs. I am hoping lots of small PRs are easier to review than a huge one, especially if some changes might be less desirable for you - that way you can just accept those (if any) you like :)